### PR TITLE
Add color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ This section is intended for use by contributors to share their work in a collab
 If you upload to this repository, it is taken that you agree to share your rights to the content with Red Eclipse in order redistribute the content under their terms. *This includes accepting that any royalties and/or revenue generated through the redistribution of the content conducted by Red Eclipse will be kept in the pool of funds for use by the project.*
 
 ## Assets
-These are things that don't belong anywhere else in the project as another repository that is already included in-game (like: fonts, sounds, textures, etc). You should use the "Akashi" and "Play Bold" from the [fonts repsository](https://github.com/redeclipse/fonts) when producing material for Red Eclipse as it will help maintain a consistent look. When looking for icons or other images to use in your work, it is recommended (but not required) you source what you can from the [textures repository](https://github.com/redeclipse/textures).
+These are things that don't belong anywhere else in the project as another repository that is already included in-game (like: fonts, sounds, textures, etc). You should use the "Akashi" and "Play Bold" from the [fonts repository](https://github.com/redeclipse/fonts) when producing material for Red Eclipse as it will help maintain a consistent look. When looking for icons or other images to use in your work, it is recommended (but not required) you source what you can from the [textures repository](https://github.com/redeclipse/textures).
 
 ## Sequences
 This is for sections of content that have a potential for being reused. Specific cuts of recordings in either audio or video format can often help with the production of further content.
 
 ## Texts
 These are little bits of text that have been used over the years for the promotion of Red Eclipse.
+
+## Colors
+These are colors that are used in the game itself or in accompanying material.
 
 # Releases
 The *releases* area is a safe haven for finished projects, and should only contain the finished files required for those productions (no raw video or cuts for the sake of size). In general you should have an "audio" track (this allows us to post it to sound/podcast sharing services), a "video" track (optional), a "thumbnail", and a "description".

--- a/colors/colors.md
+++ b/colors/colors.md
@@ -1,0 +1,47 @@
+# Colors
+
+These are colors that are used in the game itself or in accompanying material.
+
+## Brand
+
+| Name       |  Color   |
+| ---------- |:--------:|
+| Background | Dark Red |
+| Red Glow   | Red      |
+| Red Sun    | White    |
+| Dark Body  | Black    |
+
+## In-Game
+
+### Teams
+
+| Name       |  Hue   |  Value  |
+| ---------- |:------:|:-------:|
+| Team Alpha | Blue   | #1040F8 |
+| Team Omega | Red    | #FF3210 |
+| Neutral    | Grey   | #707070 |
+| Enemies¹   | Yellow | #E0E020 |
+
+These colors were extracted from [`src/game/player.h`](https://github.com/redeclipse/base/blob/6984ecb67ddbf8c4719d20517394bb44b9d2a238/src/game/player.h#L94).  
+
+¹    Used in the [`Onslaught`](https://www.redeclipse.net/docs/Modes-and-Mutators#mutators) mutator.
+
+### Weapons
+
+| Name    |   Hue  |  Value  |
+| ------- |:------:|:-------:|
+| Claw    | Orange | #907020 |
+| Pistol  | Grey   | #D0D0D0 |
+| Sword   | Blue   | #1010F0 |
+| Shotgun | Yellow | #F0F020 |
+| SMG     | Orange | #F05820 |
+| Flamer  | Red    | #F02020 |
+| Plasma  | Cyan   | #40F0C8 |
+| Zapper  | Purple | #A080F0 |
+| Rifle   | Pink   | #F020F0 |
+| Grenade | Green  | #40F000 |
+| Mine    | Green  | #00F068 |
+| Rocket  | Orange | #803000 |
+| Melee   | Grey   | #606060 |
+
+These colors were extracted from [`src/game/weapons.h`](https://github.com/redeclipse/base/blob/23be4849f2269a1b463c943cd84cbcdd39da5b2d/src/game/weapons.h#L305).


### PR DESCRIPTION
I've struggled to find exact colors to use in promotional material, so I've compiled them into a color scheme for future usage (see issue #6).

This pull requests adds the exact color values for the teams and weapons in the game,
as well as color guides for brand colors.

The colors are supplied as tables in `colors/colors.md`, along with links to the files they were extracted from.